### PR TITLE
Updates experience label to "OpenLabs"

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,7 @@
         "textExperience": "Experience",
         "textExp1": "Freelance",
         "textExp2": "No Country",
-        "textExp3": "Projects",
+        "textExp3": "OpenLabs",
         "textAbout": "About",
         "textMoreProjects": "More Projects",
         "textAboutme": "With three years of training, including one year of hands-on experience, I have specialized in UX/UI using Atomic Design. I have participated in job simulations, collaborating in teams of up to six people. In addition, I have worked on commissioned projects. Combined with my back-end knowledge, I am ready to join a professional team.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -10,7 +10,7 @@
         "textExperience": "Experiencia",
         "textExp1": "Independiente",
         "textExp2": "No Country",
-        "textExp3": "Proyectos",
+        "textExp3": "OpenLabs",
         "textAbout": "Acerca de",
         "textMoreProjects": "Más Proyectos",
         "textAboutme": "Con tres años de formación, que incluyen un año de experiencia práctica, me he especializado en UX/UI utilizando Atomic Design. He participado en simulaciones laborales, colaborando en equipos de hasta seis personas. Además, he desarrollado proyectos por encargo. Sumado a mis conocimientos en back-end, estoy preparado para integrarme a un equipo profesional.",


### PR DESCRIPTION
Renames the third experience entry from "Projects" to "OpenLabs" in both English and Spanish translations for improved clarity and consistency with actual experience names.